### PR TITLE
UI 优化：主题切换、分页跳转、导航与详情页样式重构

### DIFF
--- a/src/components/AppCard.astro
+++ b/src/components/AppCard.astro
@@ -20,7 +20,7 @@ const statusLabels: Record<App['status'], string> = {
 
 <a
 	href={href}
-	class={`group block rounded-[var(--radius-card)] border border-[var(--border)] bg-bg p-6 transition-all duration-200 hover:-translate-y-0.5 hover:border-green hover:shadow-[var(--shadow)] ${featured ? 'md:col-span-2' : ''}`}
+	class={`group block rounded-[var(--radius-card)] border border-[var(--border)] bg-bg p-6 transition-all duration-200 hover:-translate-y-0.5 hover:border-green-strong hover:shadow-[var(--shadow)] ${featured ? 'md:col-span-2' : ''}`}
 >
 	<div class="flex items-center gap-2.5">
 		{

--- a/src/components/AppCard.astro
+++ b/src/components/AppCard.astro
@@ -5,9 +5,11 @@ import type { App } from '../data/apps';
 interface Props {
 	/** src/data/apps.ts 中的应用元数据 */
 	app: App;
+	/** 大卡模式：跨两列，用于 3 个应用的非对称网格（1 大 + 2 小），奇数个应用时避免悬空 */
+	featured?: boolean;
 }
 
-const { app } = Astro.props;
+const { app, featured = false } = Astro.props;
 const href = `/apps/${app.slug}/`;
 const statusLabels: Record<App['status'], string> = {
 	development: '开发中',
@@ -18,7 +20,7 @@ const statusLabels: Record<App['status'], string> = {
 
 <a
 	href={href}
-	class="group block rounded-[var(--radius-card)] border border-[var(--border)] bg-bg p-6 transition-all duration-200 hover:-translate-y-0.5 hover:border-[var(--border-strong)] hover:shadow-[var(--shadow)]"
+	class={`group block rounded-[var(--radius-card)] border border-[var(--border)] bg-bg p-6 transition-all duration-200 hover:-translate-y-0.5 hover:border-[var(--border-strong)] hover:shadow-[var(--shadow)] ${featured ? 'md:col-span-2' : ''}`}
 >
 	<div class="flex items-center gap-2.5">
 		{
@@ -32,12 +34,12 @@ const statusLabels: Record<App['status'], string> = {
 				/>
 			)
 		}
-		<h3 class="min-w-0 flex-1 text-lg font-bold text-[var(--text)] transition-colors duration-200 group-hover:text-[var(--accent)]">
+		<h3 class={`min-w-0 flex-1 font-bold text-[var(--text)] transition-colors duration-200 group-hover:text-[var(--accent)] ${featured ? 'text-xl' : 'text-lg'}`}>
 			{app.name}
 		</h3>
 		<span class={`badge badge-${app.status}`}>{statusLabels[app.status]}</span>
 	</div>
-	<p class="mt-2 text-sm leading-relaxed text-[var(--text-soft)]">{app.description}</p>
+	<p class={`mt-2 leading-relaxed text-[var(--text-soft)] ${featured ? 'text-base' : 'text-sm'}`}>{app.description}</p>
 	<div class="mt-3 flex flex-wrap gap-2">
 		{
 			app.platforms.map((platform) => (

--- a/src/components/AppCard.astro
+++ b/src/components/AppCard.astro
@@ -20,7 +20,7 @@ const statusLabels: Record<App['status'], string> = {
 
 <a
 	href={href}
-	class={`group block rounded-[var(--radius-card)] border border-[var(--border)] bg-bg p-6 transition-all duration-200 hover:-translate-y-0.5 hover:border-[var(--border-strong)] hover:bg-[var(--bg-hover)] hover:shadow-[var(--shadow)] ${featured ? 'md:col-span-2' : ''}`}
+	class={`group block rounded-[var(--radius-card)] border border-[var(--border)] bg-bg p-6 transition-all duration-200 hover:-translate-y-0.5 hover:border-green hover:shadow-[var(--shadow)] ${featured ? 'md:col-span-2' : ''}`}
 >
 	<div class="flex items-center gap-2.5">
 		{

--- a/src/components/AppCard.astro
+++ b/src/components/AppCard.astro
@@ -20,7 +20,7 @@ const statusLabels: Record<App['status'], string> = {
 
 <a
 	href={href}
-	class={`group block rounded-[var(--radius-card)] border border-[var(--border)] bg-bg p-6 transition-all duration-200 hover:-translate-y-0.5 hover:border-dark hover:bg-dark hover:shadow-[var(--shadow)] ${featured ? 'md:col-span-2' : ''}`}
+	class={`group block rounded-[var(--radius-card)] border border-[var(--border)] bg-bg p-6 transition-all duration-200 hover:-translate-y-0.5 hover:border-[var(--border-strong)] hover:bg-[var(--bg-hover)] hover:shadow-[var(--shadow)] ${featured ? 'md:col-span-2' : ''}`}
 >
 	<div class="flex items-center gap-2.5">
 		{
@@ -34,16 +34,21 @@ const statusLabels: Record<App['status'], string> = {
 				/>
 			)
 		}
-		<h3 class={`min-w-0 flex-1 font-bold text-[var(--text)] transition-colors duration-200 group-hover:text-white ${featured ? 'text-xl' : 'text-lg'}`}>
-			{app.name}
+		<h3 class={`min-w-0 flex-1 font-bold text-[var(--text)] ${featured ? 'text-xl' : 'text-lg'}`}>
+			{
+				/* 标题 hover 变品牌绿底黑字色块（与 Hero 徽章同款），色块只包住文字不撑满整行 */
+				<span class="inline-block rounded-md px-1.5 transition-colors duration-200 group-hover:bg-green group-hover:text-black">
+					{app.name}
+				</span>
+			}
 		</h3>
 		<span class={`badge badge-${app.status}`}>{statusLabels[app.status]}</span>
 	</div>
-	<p class={`mt-2 leading-relaxed text-[var(--text-soft)] transition-colors duration-200 group-hover:text-white/70 ${featured ? 'text-base' : 'text-sm'}`}>{app.description}</p>
+	<p class={`mt-2 leading-relaxed text-[var(--text-soft)] ${featured ? 'text-base' : 'text-sm'}`}>{app.description}</p>
 	<div class="mt-3 flex flex-wrap gap-2">
 		{
 			app.platforms.map((platform) => (
-				<span class="tag-pill transition-colors duration-200 group-hover:border-white/20 group-hover:bg-white/10 group-hover:text-white/80">{platform}</span>
+				<span class="tag-pill">{platform}</span>
 			))
 		}
 	</div>

--- a/src/components/AppCard.astro
+++ b/src/components/AppCard.astro
@@ -20,7 +20,7 @@ const statusLabels: Record<App['status'], string> = {
 
 <a
 	href={href}
-	class={`group block rounded-[var(--radius-card)] border border-[var(--border)] bg-bg p-6 transition-all duration-200 hover:-translate-y-0.5 hover:border-[var(--border-strong)] hover:shadow-[var(--shadow)] ${featured ? 'md:col-span-2' : ''}`}
+	class={`group block rounded-[var(--radius-card)] border border-[var(--border)] bg-bg p-6 transition-all duration-200 hover:-translate-y-0.5 hover:border-dark hover:bg-dark hover:shadow-[var(--shadow)] ${featured ? 'md:col-span-2' : ''}`}
 >
 	<div class="flex items-center gap-2.5">
 		{
@@ -34,16 +34,16 @@ const statusLabels: Record<App['status'], string> = {
 				/>
 			)
 		}
-		<h3 class={`min-w-0 flex-1 font-bold text-[var(--text)] transition-colors duration-200 group-hover:text-[var(--accent)] ${featured ? 'text-xl' : 'text-lg'}`}>
+		<h3 class={`min-w-0 flex-1 font-bold text-[var(--text)] transition-colors duration-200 group-hover:text-white ${featured ? 'text-xl' : 'text-lg'}`}>
 			{app.name}
 		</h3>
 		<span class={`badge badge-${app.status}`}>{statusLabels[app.status]}</span>
 	</div>
-	<p class={`mt-2 leading-relaxed text-[var(--text-soft)] ${featured ? 'text-base' : 'text-sm'}`}>{app.description}</p>
+	<p class={`mt-2 leading-relaxed text-[var(--text-soft)] transition-colors duration-200 group-hover:text-white/70 ${featured ? 'text-base' : 'text-sm'}`}>{app.description}</p>
 	<div class="mt-3 flex flex-wrap gap-2">
 		{
 			app.platforms.map((platform) => (
-				<span class="tag-pill">{platform}</span>
+				<span class="tag-pill transition-colors duration-200 group-hover:border-white/20 group-hover:bg-white/10 group-hover:text-white/80">{platform}</span>
 			))
 		}
 	</div>

--- a/src/components/AppCard.astro
+++ b/src/components/AppCard.astro
@@ -20,7 +20,7 @@ const statusLabels: Record<App['status'], string> = {
 
 <a
 	href={href}
-	class={`group block rounded-[var(--radius-card)] border border-[var(--border)] bg-bg p-6 transition-all duration-200 hover:-translate-y-0.5 hover:border-green-strong hover:shadow-[var(--shadow)] ${featured ? 'md:col-span-2' : ''}`}
+	class={`group block rounded-[var(--radius-card)] border border-[var(--border-strong)] bg-bg p-6 transition-all duration-200 hover:-translate-y-0.5 hover:border-green-strong hover:shadow-[var(--shadow)] ${featured ? 'md:col-span-2' : ''}`}
 >
 	<div class="flex items-center gap-2.5">
 		{

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -6,7 +6,6 @@ const navLinks = [
 	{ name: '首页', href: '/' },
 	{ name: '应用', href: '/apps/' },
 	{ name: '博客', href: '/blog/' },
-	{ name: '时间轴', href: '/blog/timeline/' },
 	{ name: '关于', href: '/about/' },
 	{ name: '联系', href: '/contact/' },
 ];

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -17,10 +17,10 @@ const externalLinks = [
 ];
 ---
 
-<footer class="px-5 pt-12 sm:px-5">
+<footer class="px-5 pt-8 sm:px-5">
 	<div class="mx-auto w-full max-w-[1240px]">
-		<div class="rounded-t-[45px] bg-dark px-[15px] py-[45px] text-gray lg:px-[60px]">
-			<div class="flex flex-col items-center justify-between gap-7 lg:flex-row">
+		<div class="rounded-t-[45px] bg-dark px-[15px] py-8 text-gray lg:px-[60px]">
+			<div class="flex flex-col items-center justify-between gap-6 lg:flex-row">
 				<a href="/" class="flex items-center gap-2">
 					<span class="inline-block h-8 w-8 rounded-lg bg-green" aria-hidden="true"></span>
 					<span class="text-xl font-bold tracking-tight text-white">{SITE_TITLE}</span>
@@ -56,7 +56,7 @@ const externalLinks = [
 				</ul>
 			</div>
 
-			<div class="mt-10 mb-5 h-px bg-gray"></div>
+			<div class="mt-6 mb-4 h-px bg-gray"></div>
 
 			<div class="flex flex-col items-center justify-between gap-3 text-center text-sm text-gray md:flex-row">
 				<span>

--- a/src/components/LinkIcon.astro
+++ b/src/components/LinkIcon.astro
@@ -1,0 +1,39 @@
+---
+// 链接图标：下载（⬇ 下移动画）/ 外部跳转（↗ 右上动效）
+// 用于应用详情页 Hero CTA 与下载列表，配合 .group 父元素 hover 动画
+interface Props {
+	/** 下载类链接显示下载箭头，否则显示外部跳转箭头 */
+	download?: boolean;
+}
+
+const { download = false } = Astro.props;
+---
+
+{
+	download ? (
+		<svg
+			xmlns="http://www.w3.org/2000/svg"
+			fill="none"
+			viewBox="0 0 24 24"
+			stroke-width="2"
+			stroke="currentColor"
+			class="h-4 w-4 shrink-0 transition-transform duration-150 group-hover:translate-y-0.5"
+		>
+			<path stroke-linecap="round" stroke-linejoin="round" d="M12 4v12m0 0l-4-4m4 4l4-4" />
+			<path stroke-linecap="round" stroke-linejoin="round" d="M5 20h14" />
+		</svg>
+	) : (
+		<svg
+			xmlns="http://www.w3.org/2000/svg"
+			fill="none"
+			viewBox="0 0 24 24"
+			stroke-width="2"
+			stroke="currentColor"
+			class="h-4 w-4 shrink-0 transition-transform duration-150 group-hover:-translate-y-0.5 group-hover:translate-x-0.5"
+		>
+			<path stroke-linecap="round" stroke-linejoin="round" d="M14 4h6v6" />
+			<path stroke-linecap="round" stroke-linejoin="round" d="M20 4L10 14" />
+			<path stroke-linecap="round" stroke-linejoin="round" d="M14 12v6a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2v-6a2 2 0 0 1 2-2h6" />
+		</svg>
+	)
+}

--- a/src/components/Navbar.astro
+++ b/src/components/Navbar.astro
@@ -29,8 +29,8 @@ const isActive = (href: string) => {
 			<span class="text-xl font-bold tracking-tight">{SITE_TITLE}</span>
 		</a>
 
-		<!-- 桌面端导航 -->
-		<ul class="hidden items-center gap-8 md:flex">
+		<!-- 桌面端导航（ml-auto 推向右，与旧布局一致） -->
+		<ul class="hidden items-center gap-8 md:ml-auto md:flex">
 			{
 				navItems.map((item) => (
 					<li>
@@ -50,12 +50,12 @@ const isActive = (href: string) => {
 			}
 		</ul>
 
-		<div class="flex items-center gap-3">
-			<!-- 主题切换按钮：深色模式显示太阳（点击回浅色），浅色模式显示月亮 -->
+		<div class="ml-6 flex items-center gap-3">
+			<!-- 主题切换按钮：深色模式显示太阳（点击回浅色），浅色模式显示月亮；无边框，hover 圆形浅底 -->
 			<button
 				id="theme-toggle"
 				type="button"
-				class="flex h-10 w-10 items-center justify-center rounded-lg border border-[var(--text)] transition-colors duration-150 hover:bg-[var(--bg-hover)]"
+				class="flex h-10 w-10 items-center justify-center rounded-full text-[var(--text-soft)] transition-colors duration-150 hover:bg-[var(--bg-hover)] hover:text-[var(--text)]"
 				aria-label="切换主题"
 			>
 				<svg id="theme-sun" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" class="hidden h-5 w-5">

--- a/src/components/Navbar.astro
+++ b/src/components/Navbar.astro
@@ -6,13 +6,17 @@ const navItems = [
 	{ href: '/', label: '首页' },
 	{ href: '/apps/', label: '应用' },
 	{ href: '/blog/', label: '博客' },
-	{ href: '/blog/timeline/', label: '时间轴' },
 	{ href: '/about/', label: '关于' },
 	{ href: '/contact/', label: '联系' },
 ];
 
 const { pathname } = Astro.url;
-const isActive = (href: string) => (href === '/' ? pathname === '/' : pathname.startsWith(href));
+const isActive = (href: string) => {
+	if (href === '/') return pathname === '/';
+	// 时间轴不占导航位（从博客页横幅进入），其页面不高亮任何 tab
+	if (pathname.startsWith('/blog/timeline/')) return false;
+	return pathname.startsWith(href);
+};
 ---
 
 <header

--- a/src/components/Navbar.astro
+++ b/src/components/Navbar.astro
@@ -6,6 +6,7 @@ const navItems = [
 	{ href: '/', label: '首页' },
 	{ href: '/apps/', label: '应用' },
 	{ href: '/blog/', label: '博客' },
+	{ href: '/blog/timeline/', label: '时间轴' },
 	{ href: '/about/', label: '关于' },
 	{ href: '/contact/', label: '联系' },
 ];
@@ -34,8 +35,8 @@ const isActive = (href: string) => (href === '/' ? pathname === '/' : pathname.s
 							class:list={[
 								'rounded-full px-4 py-2 text-sm font-medium transition-colors duration-150',
 								isActive(item.href)
-									? 'bg-black text-white'
-									: 'text-black hover:bg-gray',
+									? 'bg-[var(--text)] text-[var(--bg)]'
+									: 'text-[var(--text)] hover:bg-[var(--bg-hover)]',
 							]}
 						>
 							{item.label}
@@ -49,7 +50,7 @@ const isActive = (href: string) => (href === '/' ? pathname === '/' : pathname.s
 		<button
 			id="nav-toggle"
 			type="button"
-			class="flex h-10 w-10 items-center justify-center rounded-lg border border-black md:hidden"
+			class="flex h-10 w-10 items-center justify-center rounded-lg border border-[var(--text)] md:hidden"
 			aria-label="切换导航菜单"
 			aria-expanded="false"
 			aria-controls="nav-mobile"
@@ -64,7 +65,7 @@ const isActive = (href: string) => (href === '/' ? pathname === '/' : pathname.s
 	</nav>
 
 	<!-- 移动端下拉菜单 -->
-	<div id="nav-mobile" class="hidden border-t border-gray bg-white md:hidden">
+	<div id="nav-mobile" class="hidden border-t border-[var(--border)] bg-[var(--bg)] md:hidden">
 		<ul class="flex flex-col px-5 py-2">
 			{
 				navItems.map((item) => (
@@ -73,7 +74,9 @@ const isActive = (href: string) => (href === '/' ? pathname === '/' : pathname.s
 							href={item.href}
 							class:list={[
 								'block rounded-lg px-3 py-3 text-base font-medium',
-								isActive(item.href) ? 'bg-black text-white' : 'text-black hover:bg-gray',
+								isActive(item.href)
+									? 'bg-[var(--text)] text-[var(--bg)]'
+									: 'text-[var(--text)] hover:bg-[var(--bg-hover)]',
 							]}
 						>
 							{item.label}
@@ -86,13 +89,14 @@ const isActive = (href: string) => (href === '/' ? pathname === '/' : pathname.s
 </header>
 
 <script>
-	// 沉浸式导航：页面在顶部时透明融入内容，滚动后浮出白底 + 边框 + 模糊
+	// 沉浸式导航：页面在顶部时透明融入内容，滚动后浮出底色 + 边框 + 模糊
+	// 底色/边框用 CSS 变量（--nav-bg / --nav-border），深色模式下自动跟随主题
 	const header = document.getElementById('site-header');
 	if (header) {
 		const applyNavState = () => {
 			const scrolled = window.scrollY > 0;
-			header.classList.toggle('bg-white/90', scrolled);
-			header.classList.toggle('border-gray', scrolled);
+			header.classList.toggle('bg-[var(--nav-bg)]', scrolled);
+			header.classList.toggle('border-[var(--nav-border)]', scrolled);
 			header.classList.toggle('backdrop-blur', scrolled);
 			header.classList.toggle('bg-transparent', !scrolled);
 			header.classList.toggle('border-transparent', !scrolled);

--- a/src/components/Navbar.astro
+++ b/src/components/Navbar.astro
@@ -50,22 +50,40 @@ const isActive = (href: string) => {
 			}
 		</ul>
 
-		<!-- 移动端汉堡按钮 -->
-		<button
-			id="nav-toggle"
-			type="button"
-			class="flex h-10 w-10 items-center justify-center rounded-lg border border-[var(--text)] md:hidden"
-			aria-label="切换导航菜单"
-			aria-expanded="false"
-			aria-controls="nav-mobile"
-		>
-			<svg id="nav-open-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" class="h-6 w-6">
-				<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16"></path>
-			</svg>
-			<svg id="nav-close-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" class="hidden h-6 w-6">
-				<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"></path>
-			</svg>
-		</button>
+		<div class="flex items-center gap-3">
+			<!-- 主题切换按钮：深色模式显示太阳（点击回浅色），浅色模式显示月亮 -->
+			<button
+				id="theme-toggle"
+				type="button"
+				class="flex h-10 w-10 items-center justify-center rounded-lg border border-[var(--text)] transition-colors duration-150 hover:bg-[var(--bg-hover)]"
+				aria-label="切换主题"
+			>
+				<svg id="theme-sun" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" class="hidden h-5 w-5">
+					<circle cx="12" cy="12" r="4"></circle>
+					<path stroke-linecap="round" stroke-width="2" d="M12 2v2m0 16v2M4.93 4.93l1.41 1.41m11.32 11.32l1.41 1.41M2 12h2m16 0h2M4.93 19.07l1.41-1.41M17.66 6.34l1.41-1.41"></path>
+				</svg>
+				<svg id="theme-moon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" class="h-5 w-5">
+					<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"></path>
+				</svg>
+			</button>
+
+			<!-- 移动端汉堡按钮 -->
+			<button
+				id="nav-toggle"
+				type="button"
+				class="flex h-10 w-10 items-center justify-center rounded-lg border border-[var(--text)] md:hidden"
+				aria-label="切换导航菜单"
+				aria-expanded="false"
+				aria-controls="nav-mobile"
+			>
+				<svg id="nav-open-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" class="h-6 w-6">
+					<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16"></path>
+				</svg>
+				<svg id="nav-close-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" class="hidden h-6 w-6">
+					<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"></path>
+				</svg>
+			</button>
+		</div>
 	</nav>
 
 	<!-- 移动端下拉菜单 -->
@@ -107,6 +125,36 @@ const isActive = (href: string) => {
 		};
 		window.addEventListener('scroll', applyNavState, { passive: true });
 		applyNavState();
+	}
+
+	// 主题切换：点击后写 data-theme + localStorage，图标随当前主题显隐
+	// 初始 data-theme 由 BaseLayout 内联脚本设置，未设置时跟随系统偏好
+	const themeToggle = document.getElementById('theme-toggle') as HTMLButtonElement;
+	const themeSun = document.getElementById('theme-sun') as unknown as SVGElement;
+	const themeMoon = document.getElementById('theme-moon') as unknown as SVGElement;
+
+	const isDarkTheme = () => {
+		const root = document.documentElement;
+		if (root.getAttribute('data-theme') === 'dark') return true;
+		if (root.getAttribute('data-theme') === 'light') return false;
+		return window.matchMedia('(prefers-color-scheme: dark)').matches;
+	};
+
+	const syncThemeIcon = () => {
+		const dark = isDarkTheme();
+		themeSun.classList.toggle('hidden', !dark);
+		themeMoon.classList.toggle('hidden', dark);
+	};
+
+	if (themeToggle && themeSun && themeMoon) {
+		syncThemeIcon();
+		themeToggle.addEventListener('click', () => {
+			const root = document.documentElement;
+			const next = isDarkTheme() ? 'light' : 'dark';
+			root.setAttribute('data-theme', next);
+			localStorage.setItem('theme', next);
+			syncThemeIcon();
+		});
 	}
 
 	// 移动端汉堡菜单切换（纯原生实现）

--- a/src/components/Pagination.astro
+++ b/src/components/Pagination.astro
@@ -1,5 +1,5 @@
 ---
-// 分页组件：上一页 / 页码列表（可点击跳转，含省略号）/ 下一页
+// 分页组件：上一页 / 页码列表（可点击跳转）/ 跳页输入框 / 下一页
 // 配合手写分页逻辑 src/lib/paginate.ts 使用
 interface Props {
 	/** 当前页码（从 1 开始） */
@@ -14,18 +14,27 @@ const { page, total, url } = Astro.props;
 const prevUrl = page > 1 ? url(page - 1) : null;
 const nextUrl = page < total ? url(page + 1) : null;
 
-// 页码窗口：当前页 ±2 + 首尾页，跳过的区间用省略号占位（如 1 2 … 6 [7] 8 … 12）
+// 全部页码的 URL（跳页输入框用，define:vars 注入前端脚本）
+const pageUrls = Array.from({ length: total }, (_, i) => url(i + 1));
+
+// 页码列表：总页数少（≤7）时全部显示，中间页直达；
+// 页数多时折叠为「当前页 ±2 + 首尾页 + 省略号」（如 1 2 … 6 [7] 8 … 12）
 const WINDOW = 2;
-const pages = new Set<number>([1, total, page]);
-for (let n = Math.max(1, page - WINDOW); n <= Math.min(total, page + WINDOW); n++) {
-	pages.add(n);
-}
-const pageList: (number | '…')[] = [];
-let prev = 0;
-for (const n of [...pages].sort((a, b) => a - b)) {
-	if (n - prev > 1) pageList.push('…');
-	pageList.push(n);
-	prev = n;
+let pageList: (number | '…')[];
+if (total <= 7) {
+	pageList = Array.from({ length: total }, (_, i) => i + 1);
+} else {
+	const pages = new Set<number>([1, total, page]);
+	for (let n = Math.max(1, page - WINDOW); n <= Math.min(total, page + WINDOW); n++) {
+		pages.add(n);
+	}
+	pageList = [];
+	let prev = 0;
+	for (const n of [...pages].sort((a, b) => a - b)) {
+		if (n - prev > 1) pageList.push('…');
+		pageList.push(n);
+		prev = n;
+	}
 }
 ---
 
@@ -37,21 +46,29 @@ for (const n of [...pages].sort((a, b) => a - b)) {
 					? <a href={prevUrl}>← 上一页</a>
 					: <span class="pagination-disabled">← 上一页</span>
 			}
-			<ul class="pagination-pages">
-				{
-					pageList.map((n) =>
-						n === '…' ? (
-							<li class="page-ellipsis" aria-hidden="true">…</li>
-						) : n === page ? (
-							<li class="page-current" aria-current="page">{n}</li>
-						) : (
-							<li>
-								<a href={url(n)}>{n}</a>
-							</li>
-						),
-					)
-				}
-			</ul>
+			<div class="pagination-center">
+				<ul class="pagination-pages">
+					{
+						pageList.map((n) =>
+							n === '…' ? (
+								<li class="page-ellipsis" aria-hidden="true">…</li>
+							) : n === page ? (
+								<li class="page-current" aria-current="page">{n}</li>
+							) : (
+								<li>
+									<a href={url(n)}>{n}</a>
+								</li>
+							),
+						)
+					}
+				</ul>
+				<form class="pagination-jump" aria-label="跳转到指定页">
+					<label for="page-jump">跳至</label>
+					<input id="page-jump" type="number" min="1" max={total} inputmode="numeric" />
+					<span>页</span>
+					<button type="submit">跳转</button>
+				</form>
+			</div>
 			{
 				nextUrl
 					? <a href={nextUrl}>下一页 →</a>
@@ -60,3 +77,19 @@ for (const n of [...pages].sort((a, b) => a - b)) {
 		</nav>
 	)
 }
+
+<script define:vars={{ pageUrls }}>
+	// 跳页输入框：提交时跳到对应 URL（仅限 1..total 范围）
+	// 注意：define:vars 内联脚本不做 TS 转译，不能使用 as 类型断言等 TS 语法
+	const form = document.querySelector('.pagination-jump');
+	const input = document.getElementById('page-jump');
+	if (form && input) {
+		form.addEventListener('submit', (e) => {
+			e.preventDefault();
+			const n = parseInt(input.value, 10);
+			if (!Number.isNaN(n) && n >= 1 && n <= pageUrls.length) {
+				location.href = pageUrls[n - 1];
+			}
+		});
+	}
+</script>

--- a/src/components/Pagination.astro
+++ b/src/components/Pagination.astro
@@ -1,5 +1,6 @@
 ---
-// 分页组件：上一页 / 页码信息 / 下一页（配合 Astro 的 paginate() 使用）
+// 分页组件：上一页 / 页码列表（可点击跳转，含省略号）/ 下一页
+// 配合手写分页逻辑 src/lib/paginate.ts 使用
 interface Props {
 	/** 当前页码（从 1 开始） */
 	page: number;
@@ -12,6 +13,20 @@ interface Props {
 const { page, total, url } = Astro.props;
 const prevUrl = page > 1 ? url(page - 1) : null;
 const nextUrl = page < total ? url(page + 1) : null;
+
+// 页码窗口：当前页 ±2 + 首尾页，跳过的区间用省略号占位（如 1 2 … 6 [7] 8 … 12）
+const WINDOW = 2;
+const pages = new Set<number>([1, total, page]);
+for (let n = Math.max(1, page - WINDOW); n <= Math.min(total, page + WINDOW); n++) {
+	pages.add(n);
+}
+const pageList: (number | '…')[] = [];
+let prev = 0;
+for (const n of [...pages].sort((a, b) => a - b)) {
+	if (n - prev > 1) pageList.push('…');
+	pageList.push(n);
+	prev = n;
+}
 ---
 
 {
@@ -22,7 +37,21 @@ const nextUrl = page < total ? url(page + 1) : null;
 					? <a href={prevUrl}>← 上一页</a>
 					: <span class="pagination-disabled">← 上一页</span>
 			}
-			<span class="pagination-info">第 {page} / {total} 页</span>
+			<ul class="pagination-pages">
+				{
+					pageList.map((n) =>
+						n === '…' ? (
+							<li class="page-ellipsis" aria-hidden="true">…</li>
+						) : n === page ? (
+							<li class="page-current" aria-current="page">{n}</li>
+						) : (
+							<li>
+								<a href={url(n)}>{n}</a>
+							</li>
+						),
+					)
+				}
+			</ul>
 			{
 				nextUrl
 					? <a href={nextUrl}>下一页 →</a>

--- a/src/components/PostCard.astro
+++ b/src/components/PostCard.astro
@@ -23,7 +23,12 @@ const dateText = pubDate.toLocaleDateString('zh-CN', {
 	<h2 class="mt-2 text-xl font-bold text-[var(--text)]">
 		<a class="transition-colors duration-150 hover:text-[var(--accent)]" href={href}>{title}</a>
 	</h2>
-	{description && <p class="mt-2 text-sm leading-relaxed text-[var(--text-soft)]">{description}</p>}
+	{
+		/* description 过滤：过短的碎片描述（如 "Problem"）不显示，避免卡片空洞 */
+		description && description.length >= 10 && (
+			<p class="mt-2 text-sm leading-relaxed text-[var(--text-soft)]">{description}</p>
+		)
+	}
 	{
 		tags.length > 0 && (
 			<div class="mt-3">

--- a/src/content/blog/CDN-HTTPS-配置.md
+++ b/src/content/blog/CDN-HTTPS-配置.md
@@ -1,6 +1,6 @@
 ---
 title: CDN HTTPS 配置
-description: 在 CDN-高级工具-证书管理界面 进行配置证书。
+description: 在CDN证书管理界面为域名配置HTTPS证书并提交部署
 pubDate: '2019-01-16'
 categories:
   - CDN

--- a/src/content/blog/CentOS7-PHP5-6-upgrade-to-PHP7-2.md
+++ b/src/content/blog/CentOS7-PHP5-6-upgrade-to-PHP7-2.md
@@ -1,6 +1,6 @@
 ---
 title: CentOS7 PHP5.6 upgrade to PHP7.2
-description: 服务器信息
+description: 记录CentOS 7下使用yum将PHP 5.6升级到7.2的完整步骤
 pubDate: '2019-01-08'
 categories:
   - Linux/CentOS

--- a/src/content/blog/C语言-auto.md
+++ b/src/content/blog/C语言-auto.md
@@ -1,6 +1,6 @@
 ---
 title: C语言 auto
-description: auto 被解释为一个自动存储变量的关键字，也就是申明一块临时的变量内存。
+description: auto在C语言中声明自动存储变量，在C++中作为类型说明符推断类型
 pubDate: '2020-08-26'
 categories:
   - C

--- a/src/content/blog/Downloading-CanvasKit-failure-error-when-running-flutter-on-brower.md
+++ b/src/content/blog/Downloading-CanvasKit-failure-error-when-running-flutter-on-brower.md
@@ -1,6 +1,6 @@
 ---
 title: Downloading CanvasKit failure error when running flutter on brower
-description: Reason
+description: Flutter浏览器端下载CanvasKit失败，通过配置国内镜像源解决
 pubDate: '2022-02-17'
 tags:
   - flutter

--- a/src/content/blog/Fliqlo-翻页时钟屏保.md
+++ b/src/content/blog/Fliqlo-翻页时钟屏保.md
@@ -1,6 +1,6 @@
 ---
 title: Fliqlo 翻页时钟屏保
-description: 官方网址：https://fliqlo.com/
+description: Fliqlo翻页时钟屏保的官方网址与效果图展示
 pubDate: '2019-07-20'
 categories:
   - 推荐

--- a/src/content/blog/Java内存区域与JVM垃圾回收.md
+++ b/src/content/blog/Java内存区域与JVM垃圾回收.md
@@ -1,6 +1,6 @@
 ---
 title: Java内存区域与JVM垃圾回收
-description: 当前文章基于JDK1.8版本，JVM版本为HotSpot。
+description: 基于JDK1.8的HotSpot介绍Java内存区域划分与JVM垃圾回收机制
 pubDate: '2024-03-18'
 ---
 

--- a/src/content/blog/LeetCode-single-number.md
+++ b/src/content/blog/LeetCode-single-number.md
@@ -1,6 +1,6 @@
 ---
 title: '[LeetCode] single number'
-description: Single Number
+description: 利用异或运算找出数组中只出现一次的数字
 pubDate: '2020-08-31'
 tags:
   - LeetCode

--- a/src/content/blog/LeetCode-整数反转.md
+++ b/src/content/blog/LeetCode-整数反转.md
@@ -1,6 +1,6 @@
 ---
 title: LeetCode 整数反转
-description: 我采用的策略
+description: 通过字符串反转实现整数反转并处理符号与溢出问题
 pubDate: '2018-12-29'
 tags:
   - LeetCode

--- a/src/content/blog/Linux下安装Oracle客户端.md
+++ b/src/content/blog/Linux下安装Oracle客户端.md
@@ -1,6 +1,6 @@
 ---
 title: Linux下安装Oracle客户端
-description: 下载RPM包 RPM版本： 需要手动安装
+description: Linux下安装Oracle Instant Client并配置环境变量的完整步骤
 pubDate: '2019-08-12'
 categories:
   - Linux

--- a/src/content/blog/Nginx-server-SSL-configuration-file-reference.md
+++ b/src/content/blog/Nginx-server-SSL-configuration-file-reference.md
@@ -1,6 +1,6 @@
 ---
 title: Nginx server SSL configuration file reference
-description: 以下配置文件供参考，此配置在当前网站可用。
+description: Nginx服务器SSL配置参考，含HTTP跳转HTTPS与证书加载设置
 pubDate: '2020-12-19'
 tags:
   - Nginx

--- a/src/content/blog/Nginx-uWsgi-重新运行Django项目.md
+++ b/src/content/blog/Nginx-uWsgi-重新运行Django项目.md
@@ -1,6 +1,6 @@
 ---
 title: Nginx uWsgi 重新运行Django项目
-description: 重新启动NGINX 重新加载网站配置文件 sh nginx -s reload
+description: Django项目重新运行指南，重载Nginx配置并重启uWSGI服务
 pubDate: '2019-02-20'
 tags:
   - Nginx

--- a/src/content/blog/SM4-国密算法.md
+++ b/src/content/blog/SM4-国密算法.md
@@ -1,6 +1,6 @@
 ---
 title: SM4 国密算法
-description: SM4 算法
+description: 介绍国密SM4分组对称加密算法的原理与Go代码实现
 pubDate: '2021-12-18'
 tags:
   - sm4

--- a/src/content/blog/SSH连接WSL.md
+++ b/src/content/blog/SSH连接WSL.md
@@ -1,6 +1,6 @@
 ---
 title: SSH连接WSL
-description: 重装 openssh-server
+description: 重装openssh-server并配置sshd_config后用SSH连接WSL
 pubDate: '2019-12-13'
 tags:
   - WSL

--- a/src/content/blog/Smart-Light-Strip.md
+++ b/src/content/blog/Smart-Light-Strip.md
@@ -1,6 +1,6 @@
 ---
 title: Smart Light Strip
-description: ESP8266 (LiLon NodeMcu V3)
+description: How to build a smart light strip with ESP8266 and the Blinker app
 pubDate: '2021-06-26'
 tags:
   - Blinker

--- a/src/content/blog/Typero自动上传图片到Tencent-Cos.md
+++ b/src/content/blog/Typero自动上传图片到Tencent-Cos.md
@@ -1,6 +1,6 @@
 ---
 title: Typero自动上传图片到Tencent COS
-description: Python实现上传脚本
+description: 用Python编写上传脚本让Typora自动上传图片到腾讯COS
 pubDate: '2020-11-29'
 tags:
   - Python

--- a/src/content/blog/Vue-js-learning-notes.md
+++ b/src/content/blog/Vue-js-learning-notes.md
@@ -1,6 +1,6 @@
 ---
 title: Vue.js learning notes
-description: Vue.js
+description: Vue.js学习笔记，涵盖渲染方式、指令、组件与路由等核心概念
 pubDate: '2021-12-12'
 tags:
   - vue

--- a/src/content/blog/Windows下迁移User下的用户目录到非系统盘.md
+++ b/src/content/blog/Windows下迁移User下的用户目录到非系统盘.md
@@ -1,6 +1,6 @@
 ---
 title: Windows下迁移User下的用户目录到非系统盘
-description: 1. 先进入Windows的修复模式，进入修复模式的命令行功能。
+description: 通过修复模式与robocopy将用户目录迁移到非系统盘并建立软链接
 pubDate: '2020-12-15'
 tags:
   - Windows

--- a/src/content/blog/bing2-网站页面加载优化.md
+++ b/src/content/blog/bing2-网站页面加载优化.md
@@ -1,6 +1,6 @@
 ---
 title: bing2 网站页面加载优化
-description: 网站：http://bing.tzz6.xyz
+description: 通过懒加载、缩略图与CDN加速优化网站页面加载速度
 pubDate: '2019-03-24'
 tags:
   - bing2

--- a/src/content/blog/cx-Oracle-DPI-1047-Cannot-locate-a-64-bit-Oracle-Client-library.md
+++ b/src/content/blog/cx-Oracle-DPI-1047-Cannot-locate-a-64-bit-Oracle-Client-library.md
@@ -1,6 +1,6 @@
 ---
 title: 'cx_Oracle DPI-1047: Cannot locate a 64-bit Oracle Client library'
-description: QUESTION
+description: cx_Oracle报错DPI-1047无法定位64位Oracle客户端库的排查方法
 pubDate: '2021-08-14'
 tags:
   - Python

--- a/src/content/blog/fixed-bash-command-not-found-when-using-ssh-connect-to-server.md
+++ b/src/content/blog/fixed-bash-command-not-found-when-using-ssh-connect-to-server.md
@@ -1,6 +1,6 @@
 ---
 title: '[fixed]-bash: command not found when using ssh connect to server'
-description: Problem
+description: SSH连接服务器执行脚本报command not found，因脚本中PATH变量覆盖环境变量所致
 pubDate: '2022-02-21'
 tags:
   - ssh

--- a/src/content/blog/hexo-bug.md
+++ b/src/content/blog/hexo-bug.md
@@ -1,6 +1,6 @@
 ---
 title: Hexo bug
-description: 修改文章的大小写后，重新部署无效
+description: 修改文章文件名大小写后部署无效的原因与解决办法
 pubDate: '2018-12-13'
 tags:
   - Hexo

--- a/src/content/blog/hexo-更换主题.md
+++ b/src/content/blog/hexo-更换主题.md
@@ -1,6 +1,6 @@
 ---
 title: hexo 更换主题
-description: 选择主题
+description: Hexo更换NexT主题的下载、安装与配置步骤
 pubDate: '2018-11-16'
 tags:
   - Hexo

--- a/src/content/blog/installing-and-setting-up-kubectl-on-Linux.md
+++ b/src/content/blog/installing-and-setting-up-kubectl-on-Linux.md
@@ -1,6 +1,6 @@
 ---
 title: Installing and setting up kubectl on Linux
-description: 安装kubectl
+description: Linux下安装kubectl并配置自动补全与插件的步骤
 pubDate: '2021-10-17'
 tags:
   - kubectl

--- a/src/content/blog/springboot-thymeleaf不渲染页面返回字符串.md
+++ b/src/content/blog/springboot-thymeleaf不渲染页面返回字符串.md
@@ -1,6 +1,6 @@
 ---
 title: springboot thymeleaf不渲染页面返回字符串
-description: 错误信息：
+description: Spring Boot页面不渲染而返回字符串，解析@RestController与@Controller的区别
 pubDate: '2019-03-30'
 ---
 

--- a/src/content/blog/修改wordpress的翻译文件.md
+++ b/src/content/blog/修改wordpress的翻译文件.md
@@ -1,6 +1,6 @@
 ---
 title: 修改wordpress的翻译文件
-description: 之前WordPress博客的首页部分内容翻译错误，就想手动修改一下。
+description: 用Poedit修改WordPress主题翻译文件并编译为mo文件后上传覆盖
 pubDate: '2018-11-20'
 tags:
   - WordPress

--- a/src/content/blog/删除电脑文件夹中右键菜单-授予访问权限选项.md
+++ b/src/content/blog/删除电脑文件夹中右键菜单-授予访问权限选项.md
@@ -1,6 +1,6 @@
 ---
 title: 删除电脑文件夹中右键菜单-授予访问权限选项
-description: 删除电脑文件夹中右键菜单-授予访问权限 选项
+description: 通过注册表删除文件夹右键菜单中的授予访问权限选项
 pubDate: '2019-12-13'
 tags:
   - Windows

--- a/src/content/blog/在Apache服务器上运行Django项目.md
+++ b/src/content/blog/在Apache服务器上运行Django项目.md
@@ -1,6 +1,6 @@
 ---
 title: 在Apache服务器上运行Django项目
-description: 服务器版本:CentOS 7.5
+description: 在CentOS 7.5的Apache服务器上安装mod_wsgi以运行Django项目
 pubDate: '2018-12-14'
 categories:
   - Apache

--- a/src/content/blog/在Docker-Alpine中安装uwsgi.md
+++ b/src/content/blog/在Docker-Alpine中安装uwsgi.md
@@ -1,6 +1,6 @@
 ---
 title: 在Docker Alpine中安装uwsgi
-description: uWSGI是一个由unbit提供的Web应用服务器，实现了WSGI规范。
+description: 在精简的Docker Alpine镜像中安装uwsgi失败时需先安装编译依赖包
 pubDate: '2019-02-19'
 categories:
   - Linux/Alpine

--- a/src/content/blog/简单理解-java-lang-Throwable.md
+++ b/src/content/blog/简单理解-java-lang-Throwable.md
@@ -1,6 +1,6 @@
 ---
 title: 简单理解 java.lang.Throwable
-description: java.lang.Throwable
+description: 简单理解java.lang.Throwable及Error与Exception两大子类的区别
 pubDate: '2022-08-15'
 tags:
   - Java

--- a/src/content/blog/网站开启CDN加速.md
+++ b/src/content/blog/网站开启CDN加速.md
@@ -1,6 +1,6 @@
 ---
 title: 网站开启CDN加速
-description: CDN
+description: 通过腾讯云CDN为网站开启加速并配置缓存规则
 pubDate: '2019-01-16'
 cover: https://img.alicdn.com/tfs/TB1jxiiG49YBuNjy0FfXXXIsVXa-1530-1140.png
 ---

--- a/src/content/blog/解决Linux下Oracle客户端无法连接Windows下Oracle-Server端问题的方法.md
+++ b/src/content/blog/解决Linux下Oracle客户端无法连接Windows下Oracle-Server端问题的方法.md
@@ -1,6 +1,6 @@
 ---
 title: 解决Linux下Oracle客户端无法连接Windows下Oracle Server端问题的方法
-description: 查看SERVICE_NAME
+description: 通过查询SERVICE_NAME并修改tnsnames.ora解决Oracle客户端跨平台连接问题
 pubDate: '2019-08-13'
 categories:
   - Linux

--- a/src/content/blog/配置Flutter国内镜像源.md
+++ b/src/content/blog/配置Flutter国内镜像源.md
@@ -1,6 +1,6 @@
 ---
 title: 配置Flutter国内镜像源
-description: Windows
+description: 配置PUB_HOSTED_URL与FLUTTER_STORAGE_BASE_URL环境变量使用Flutter国内镜像源
 pubDate: '2022-02-17'
 tags:
   - flutter

--- a/src/content/blog/配置Github Actions过程中的一些问题.md
+++ b/src/content/blog/配置Github Actions过程中的一些问题.md
@@ -1,6 +1,6 @@
 ---
 title: 配置Github Actions过程中的一些问题
-description: 1. 在Actions中切换分支
+description: 记录Github Actions中切换分支与SSH远程登录服务器的问题解决过程
 pubDate: '2020-12-19'
 tags:
   - CI/CD

--- a/src/data/apps.ts
+++ b/src/data/apps.ts
@@ -34,18 +34,6 @@ export interface App {
 /** 全部应用，顺序即列表页展示顺序 */
 export const apps: App[] = [
   {
-    slug: 'comment-doc-lens',
-    name: 'Comment Doc Lens',
-    description: '在 VS Code 引用处以内联提示展示定义注释与符号文档',
-    status: 'released',
-    platforms: ['VS Code'],
-    icon: '/images/apps/comment-doc-lens/icon.png',
-    links: {
-      marketplace: 'https://marketplace.visualstudio.com/items?itemName=tanzz.comment-doc-lens',
-      github: 'https://github.com/tzzs/comment-doc-lens',
-    },
-  },
-  {
     slug: 'thrift-support',
     name: 'Thrift Support',
     description: 'Apache Thrift IDL 语言智能支持：语法高亮、格式化、诊断与代码导航',
@@ -56,6 +44,18 @@ export const apps: App[] = [
       marketplace: 'https://marketplace.visualstudio.com/items?itemName=tanzz.thrift-support',
       openVsx: 'https://open-vsx.org/extension/tanzz/thrift-support',
       github: 'https://github.com/tzzs/vsce-thrift-support',
+    },
+  },
+  {
+    slug: 'comment-doc-lens',
+    name: 'Comment Doc Lens',
+    description: '在 VS Code 引用处以内联提示展示定义注释与符号文档',
+    status: 'released',
+    platforms: ['VS Code'],
+    icon: '/images/apps/comment-doc-lens/icon.png',
+    links: {
+      marketplace: 'https://marketplace.visualstudio.com/items?itemName=tanzz.comment-doc-lens',
+      github: 'https://github.com/tzzs/comment-doc-lens',
     },
   },
   {

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -18,6 +18,17 @@ const canonicalURL = new URL(Astro.url.pathname, Astro.site);
 const ogImage = image ? new URL(image, Astro.site) : undefined;
 ---
 
+<!-- 主题初始化：localStorage 优先，未保存过则跟随系统偏好（置于 CSS 前，避免切换闪烁） -->
+<script is:inline>
+	(function () {
+		var saved = localStorage.getItem('theme');
+		var el = document.documentElement;
+		if (saved === 'dark') el.setAttribute('data-theme', 'dark');
+		else if (saved === 'light') el.setAttribute('data-theme', 'light');
+		// 未保存过：不设置 data-theme，CSS 通过 color-scheme: light dark 跟随系统
+	})();
+</script>
+
 <!-- 基础元信息 -->
 <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -19,7 +19,7 @@ const techStack = ['Java', 'C', 'Python', 'Go', 'Linux', '数据库'];
 				关于<span class="ml-3 inline-block rounded-2xl bg-green px-3 py-1">我</span>
 			</h1>
 			<p class="mt-7 max-w-2xl text-lg leading-relaxed text-[var(--text-soft)]">
-				你好，我是 <strong class="font-bold text-black">TZZ</strong>，
+				你好，我是 <strong class="font-bold text-[var(--text)]">TZZ</strong>，
 				独立开发者，平时做点开发工具，写写技术博客。
 			</p>
 		</header>

--- a/src/pages/apps/[slug]/index.astro
+++ b/src/pages/apps/[slug]/index.astro
@@ -95,8 +95,8 @@ const IntroContent = introEntry ? (await render(introEntry)).Content : undefined
 				primaryLink && (
 					<div class="mt-7 flex flex-wrap items-center gap-3">
 						<a
-							/* 详情页 Hero 比主页首屏低一级：按钮从 hero 尺寸（py-4 px-7）收窄一档 */
-							class="btn-tertiary group px-5 py-2.5"
+							/* 主 CTA：迷你实底按钮（px-4 py-2），详情页比主页首屏低两级 */
+							class="btn-tertiary group px-4 py-2 text-sm"
 							href={primaryLink[1]}
 							target="_blank"
 							rel="noopener noreferrer"
@@ -108,7 +108,8 @@ const IntroContent = introEntry ? (await render(introEntry)).Content : undefined
 							/* 主链接已是 GitHub 时不重复展示次按钮 */
 							githubUrl && primaryLink[0] !== 'github' && (
 								<a
-									class="btn-secondary group px-5 py-2.5"
+									/* 次 CTA：幽灵胶囊（同下载区样式），实底主按钮不抢层级 */
+									class="group inline-flex items-center gap-1.5 rounded-full border border-[var(--border)] px-4 py-2 text-sm font-medium text-[var(--text-soft)] transition-colors duration-200 hover:border-[var(--accent)] hover:text-[var(--accent)]"
 									href={githubUrl}
 									target="_blank"
 									rel="noopener noreferrer"

--- a/src/pages/apps/[slug]/index.astro
+++ b/src/pages/apps/[slug]/index.astro
@@ -189,7 +189,7 @@ const IntroContent = introEntry ? (await render(introEntry)).Content : undefined
 					<span class="mt-0.5 block text-sm text-text-faint">版本记录与变更说明</span>
 				</span>
 				<span class="flex h-11 w-11 shrink-0 items-center justify-center rounded-full bg-green text-black transition-colors duration-200 group-hover:bg-black group-hover:text-green">
-					<svg class="h-5 w-5 transition-transform duration-200 group-hover:translate-x-0.5" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor">
+					<svg class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor">
 						<path stroke-linecap="round" stroke-linejoin="round" d="M5 12h14m0 0l-6-6m6 6l-6 6" />
 					</svg>
 				</span>
@@ -205,7 +205,7 @@ const IntroContent = introEntry ? (await render(introEntry)).Content : undefined
 					<span class="mt-0.5 block text-sm text-text-faint">数据收集与使用说明</span>
 				</span>
 				<span class="flex h-11 w-11 shrink-0 items-center justify-center rounded-full bg-green text-black transition-colors duration-200 group-hover:bg-black group-hover:text-green">
-					<svg class="h-5 w-5 transition-transform duration-200 group-hover:translate-x-0.5" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor">
+					<svg class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor">
 						<path stroke-linecap="round" stroke-linejoin="round" d="M5 12h14m0 0l-6-6m6 6l-6 6" />
 					</svg>
 				</span>

--- a/src/pages/apps/[slug]/index.astro
+++ b/src/pages/apps/[slug]/index.astro
@@ -65,8 +65,8 @@ const IntroContent = introEntry ? (await render(introEntry)).Content : undefined
 
 <MainLayout title={`${app.name} - ${SITE_TITLE}`} description={app.description}>
 	<article>
-		<!-- Hero：图标 + 名称 + 描述 + 状态徽章 + 平台 + 下载入口 -->
-		<header class="py-10 md:py-12">
+		<!-- Hero：图标 + 名称 + 描述 + 状态徽章 + 平台 + 下载入口（底部收紧，衔接产品介绍） -->
+		<header class="pt-10 pb-6 md:pt-12 md:pb-8">
 			<h1 class="flex items-center gap-4 text-3xl font-bold tracking-tight md:text-4xl">
 				{
 					app.icon && (
@@ -95,8 +95,8 @@ const IntroContent = introEntry ? (await render(introEntry)).Content : undefined
 				primaryLink && (
 					<div class="mt-7 flex flex-wrap items-center gap-3">
 						<a
-							/* 主 CTA：幽灵胶囊（与次按钮同款低调样式），hover 变主题蓝 */
-							class="group inline-flex items-center gap-1.5 rounded-full border border-[var(--border)] px-4 py-2 text-sm font-medium text-[var(--text-soft)] transition-colors duration-200 hover:border-[var(--accent)] hover:text-[var(--accent)]"
+							/* 主 CTA：绿色实底（对比用），hover 反色 */
+							class="btn-tertiary group px-4 py-2 text-sm"
 							href={primaryLink[1]}
 							target="_blank"
 							rel="noopener noreferrer"
@@ -108,8 +108,8 @@ const IntroContent = introEntry ? (await render(introEntry)).Content : undefined
 							/* 主链接已是 GitHub 时不重复展示次按钮 */
 							githubUrl && primaryLink[0] !== 'github' && (
 								<a
-									/* 次 CTA：幽灵胶囊（同下载区样式），实底主按钮不抢层级 */
-									class="group inline-flex items-center gap-1.5 rounded-full border border-[var(--border)] px-4 py-2 text-sm font-medium text-[var(--text-soft)] transition-colors duration-200 hover:border-[var(--accent)] hover:text-[var(--accent)]"
+									/* 次 CTA：绿色实底（与主按钮同款，对比用） */
+									class="btn-tertiary group px-4 py-2 text-sm"
 									href={githubUrl}
 									target="_blank"
 									rel="noopener noreferrer"
@@ -125,7 +125,7 @@ const IntroContent = introEntry ? (await render(introEntry)).Content : undefined
 		</header>
 
 		<!-- 产品介绍与功能：渲染 index.md -->
-		<section class="mt-10" aria-labelledby="intro-heading">
+		<section class="mt-5" aria-labelledby="intro-heading">
 			<h2
 				id="intro-heading"
 				class="mb-6 border-b border-border pb-3 text-2xl font-bold tracking-tight"
@@ -154,12 +154,12 @@ const IntroContent = introEntry ? (await render(introEntry)).Content : undefined
 			</h2>
 			{
 				linkEntries.length > 0 ? (
-					/* 下载列表：胶囊按钮（与主页「查看全部」同款幽灵样式），hover 变主题蓝 */
+					/* 下载列表：绿色实底迷你按钮，与 Hero CTA 同款样式 */
 					<ul class="flex flex-wrap gap-3">
 						{linkEntries.map(([key, url]) => (
 							<li>
 								<a
-									class="group inline-flex items-center gap-1.5 rounded-full border border-[var(--border)] px-4 py-1.5 text-sm font-medium text-[var(--text-soft)] transition-colors duration-200 hover:border-[var(--accent)] hover:text-[var(--accent)]"
+									class="btn-tertiary group px-4 py-2 text-sm"
 									href={url}
 									target="_blank"
 									rel="noopener noreferrer"
@@ -176,25 +176,39 @@ const IntroContent = introEntry ? (await render(introEntry)).Content : undefined
 			}
 		</section>
 
-		<!-- 子页导航：更新日志 + 隐私政策（卡片式链接） -->
+		<!-- 子页导航：更新日志 + 隐私政策（卡片式链接 + 圆形箭头按钮，明确可点击） -->
 		<nav class="mt-10 grid gap-6 md:grid-cols-2" aria-label={`${app.name} 子页面导航`}>
 			<a
-				class="group block rounded-[var(--radius-card)] border border-[var(--border)] bg-bg p-6 transition-all duration-200 hover:-translate-y-0.5 hover:border-[var(--border-strong)] hover:shadow-[var(--shadow)]"
+				class="group flex items-center justify-between gap-4 rounded-[var(--radius-card)] border border-[var(--border)] bg-bg p-6 transition-all duration-200 hover:-translate-y-0.5 hover:border-[var(--border-strong)] hover:shadow-[var(--shadow)]"
 				href={`/apps/${app.slug}/changelog/`}
 			>
-				<span class="block font-semibold text-text transition-colors duration-200 group-hover:text-accent">
-					更新日志
+				<span class="min-w-0">
+					<span class="block font-semibold text-text transition-colors duration-200 group-hover:text-accent">
+						更新日志
+					</span>
+					<span class="mt-0.5 block text-sm text-text-faint">版本记录与变更说明</span>
 				</span>
-				<span class="mt-0.5 block text-sm text-text-faint">版本记录与变更说明</span>
+				<span class="flex h-11 w-11 shrink-0 items-center justify-center rounded-full bg-green text-black transition-colors duration-200 group-hover:bg-black group-hover:text-green">
+					<svg class="h-5 w-5 transition-transform duration-200 group-hover:translate-x-0.5" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor">
+						<path stroke-linecap="round" stroke-linejoin="round" d="M5 12h14m0 0l-6-6m6 6l-6 6" />
+					</svg>
+				</span>
 			</a>
 			<a
-				class="group block rounded-[var(--radius-card)] border border-[var(--border)] bg-bg p-6 transition-all duration-200 hover:-translate-y-0.5 hover:border-[var(--border-strong)] hover:shadow-[var(--shadow)]"
+				class="group flex items-center justify-between gap-4 rounded-[var(--radius-card)] border border-[var(--border)] bg-bg p-6 transition-all duration-200 hover:-translate-y-0.5 hover:border-[var(--border-strong)] hover:shadow-[var(--shadow)]"
 				href={`/apps/${app.slug}/privacy/`}
 			>
-				<span class="block font-semibold text-text transition-colors duration-200 group-hover:text-accent">
-					隐私政策
+				<span class="min-w-0">
+					<span class="block font-semibold text-text transition-colors duration-200 group-hover:text-accent">
+						隐私政策
+					</span>
+					<span class="mt-0.5 block text-sm text-text-faint">数据收集与使用说明</span>
 				</span>
-				<span class="mt-0.5 block text-sm text-text-faint">数据收集与使用说明</span>
+				<span class="flex h-11 w-11 shrink-0 items-center justify-center rounded-full bg-green text-black transition-colors duration-200 group-hover:bg-black group-hover:text-green">
+					<svg class="h-5 w-5 transition-transform duration-200 group-hover:translate-x-0.5" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor">
+						<path stroke-linecap="round" stroke-linejoin="round" d="M5 12h14m0 0l-6-6m6 6l-6 6" />
+					</svg>
+				</span>
 			</a>
 		</nav>
 	</article>

--- a/src/pages/apps/[slug]/index.astro
+++ b/src/pages/apps/[slug]/index.astro
@@ -4,6 +4,7 @@
 // 已知应用但内容缺失时优雅降级为占位提示。
 import { getCollection, render } from 'astro:content';
 import MainLayout from '../../../layouts/MainLayout.astro';
+import LinkIcon from '../../../components/LinkIcon.astro';
 import { apps, type App, type AppStatus } from '../../../data/apps';
 import { SITE_TITLE } from '../../../consts';
 
@@ -46,6 +47,14 @@ const labelFor = (key: string) => linkLabels[key] ?? key;
 
 const linkEntries = Object.entries(app.links ?? {});
 
+// 主下载链接：apps.ts 中 links 的第一个即主渠道（如 marketplace），作为 Hero 主 CTA
+const primaryLink = linkEntries[0];
+const githubUrl = app.links?.github;
+
+// 判断链接是否为下载类（安装包直链），决定图标（⬇ 下载 / ↗ 外部）
+const isDownloadUrl = (key: string, url: string) =>
+	key === 'download' || /\.(exe|msi|zip|vsix|dmg|apk)$/i.test(url);
+
 // 产品介绍：src/content/apps/<slug>/index.md
 // Astro 7 glob loader：entry.id = slug（文件名去扩展名，且尾部 /index 被移除）
 const introEntry = (await getCollection('apps')).find(
@@ -75,12 +84,43 @@ const IntroContent = introEntry ? (await render(introEntry)).Content : undefined
 			<p class="mt-3 max-w-[42em] text-lg leading-relaxed text-text-soft">
 				{app.description}
 			</p>
-			<div class="mt-4 flex flex-wrap items-center gap-3">
+			<div class="mt-5 flex flex-wrap items-center gap-3">
 				<span class:list={['badge', `badge-${app.status}`]}>
 					{statusLabels[app.status] ?? app.status}
 				</span>
 				<span class="text-sm text-text-faint">{app.platforms.join(' / ')}</span>
 			</div>
+			{
+				/* 主 CTA：第一眼直达下载渠道（主链接绿色实底 + GitHub 白底次按钮），下载区保留完整列表 */
+				primaryLink && (
+					<div class="mt-7 flex flex-wrap items-center gap-3">
+						<a
+							/* 详情页 Hero 比主页首屏低一级：按钮从 hero 尺寸（py-4 px-7）收窄一档 */
+							class="btn-tertiary group px-5 py-2.5"
+							href={primaryLink[1]}
+							target="_blank"
+							rel="noopener noreferrer"
+						>
+							{labelFor(primaryLink[0])}
+							<LinkIcon download={isDownloadUrl(primaryLink[0], primaryLink[1])} />
+						</a>
+						{
+							/* 主链接已是 GitHub 时不重复展示次按钮 */
+							githubUrl && primaryLink[0] !== 'github' && (
+								<a
+									class="btn-secondary group px-5 py-2.5"
+									href={githubUrl}
+									target="_blank"
+									rel="noopener noreferrer"
+								>
+									GitHub 仓库
+									<LinkIcon />
+								</a>
+							)
+						}
+					</div>
+				)
+			}
 		</header>
 
 		<!-- 产品介绍与功能：渲染 index.md -->
@@ -103,7 +143,7 @@ const IntroContent = introEntry ? (await render(introEntry)).Content : undefined
 			}
 		</section>
 
-		<!-- 下载：app.links 渲染为带图标的下划线链接（下载 ⬇ / 外部 ↗） -->
+		<!-- 下载：app.links 渲染为胶囊按钮（下载 ⬇ / 外部 ↗），主渠道已作为 Hero 主 CTA -->
 		<section class="mt-10" aria-labelledby="download-heading">
 			<h2
 				id="download-heading"
@@ -113,51 +153,21 @@ const IntroContent = introEntry ? (await render(introEntry)).Content : undefined
 			</h2>
 			{
 				linkEntries.length > 0 ? (
-					<ul class="flex flex-wrap gap-x-6 gap-y-3">
-						{linkEntries.map(([key, url]) => {
-							const isDownload =
-								key === 'download' || /\.(exe|msi|zip|vsix|dmg|apk)$/i.test(url);
-							return (
-								<li>
-									<a
-										class="group inline-flex items-center gap-1.5 font-medium text-accent underline decoration-accent/40 underline-offset-4 transition-colors duration-150 hover:text-[#0a4fb0] hover:decoration-accent"
-										href={url}
-										target="_blank"
-										rel="noopener noreferrer"
-									>
-										{labelFor(key)}
-										{
-											isDownload ? (
-												<svg
-													xmlns="http://www.w3.org/2000/svg"
-													fill="none"
-													viewBox="0 0 24 24"
-													stroke-width="2"
-													stroke="currentColor"
-													class="h-4 w-4 shrink-0 transition-transform duration-150 group-hover:translate-y-0.5"
-												>
-													<path stroke-linecap="round" stroke-linejoin="round" d="M12 4v12m0 0l-4-4m4 4l4-4" />
-													<path stroke-linecap="round" stroke-linejoin="round" d="M5 20h14" />
-												</svg>
-											) : (
-												<svg
-													xmlns="http://www.w3.org/2000/svg"
-													fill="none"
-													viewBox="0 0 24 24"
-													stroke-width="2"
-													stroke="currentColor"
-													class="h-4 w-4 shrink-0 transition-transform duration-150 group-hover:-translate-y-0.5 group-hover:translate-x-0.5"
-												>
-													<path stroke-linecap="round" stroke-linejoin="round" d="M14 4h6v6" />
-													<path stroke-linecap="round" stroke-linejoin="round" d="M20 4L10 14" />
-													<path stroke-linecap="round" stroke-linejoin="round" d="M14 12v6a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2v-6a2 2 0 0 1 2-2h6" />
-												</svg>
-											)
-										}
-									</a>
-								</li>
-							);
-						})}
+					/* 下载列表：胶囊按钮（与主页「查看全部」同款幽灵样式），hover 变主题蓝 */
+					<ul class="flex flex-wrap gap-3">
+						{linkEntries.map(([key, url]) => (
+							<li>
+								<a
+									class="group inline-flex items-center gap-1.5 rounded-full border border-[var(--border)] px-4 py-1.5 text-sm font-medium text-[var(--text-soft)] transition-colors duration-200 hover:border-[var(--accent)] hover:text-[var(--accent)]"
+									href={url}
+									target="_blank"
+									rel="noopener noreferrer"
+								>
+									{labelFor(key)}
+									<LinkIcon download={isDownloadUrl(key, url)} />
+								</a>
+							</li>
+						))}
 					</ul>
 				) : (
 					<p class="text-text-faint">敬请期待</p>

--- a/src/pages/apps/[slug]/index.astro
+++ b/src/pages/apps/[slug]/index.astro
@@ -65,8 +65,8 @@ const IntroContent = introEntry ? (await render(introEntry)).Content : undefined
 
 <MainLayout title={`${app.name} - ${SITE_TITLE}`} description={app.description}>
 	<article>
-		<!-- Hero：图标 + 名称 + 描述 + 状态徽章 + 平台 -->
-		<header class="border-b border-border py-10 md:py-12">
+		<!-- Hero：图标 + 名称 + 描述 + 状态徽章 + 平台 + 下载入口 -->
+		<header class="py-10 md:py-12">
 			<h1 class="flex items-center gap-4 text-3xl font-bold tracking-tight md:text-4xl">
 				{
 					app.icon && (
@@ -95,8 +95,8 @@ const IntroContent = introEntry ? (await render(introEntry)).Content : undefined
 				primaryLink && (
 					<div class="mt-7 flex flex-wrap items-center gap-3">
 						<a
-							/* 主 CTA：迷你实底按钮（px-4 py-2），详情页比主页首屏低两级 */
-							class="btn-tertiary group px-4 py-2 text-sm"
+							/* 主 CTA：幽灵胶囊（与次按钮同款低调样式），hover 变主题蓝 */
+							class="group inline-flex items-center gap-1.5 rounded-full border border-[var(--border)] px-4 py-2 text-sm font-medium text-[var(--text-soft)] transition-colors duration-200 hover:border-[var(--accent)] hover:text-[var(--accent)]"
 							href={primaryLink[1]}
 							target="_blank"
 							rel="noopener noreferrer"

--- a/src/pages/apps/index.astro
+++ b/src/pages/apps/index.astro
@@ -20,7 +20,7 @@ import { SITE_TITLE } from '../../consts';
 	{
 		apps.length > 0 ? (
 			<div class="grid gap-6 md:grid-cols-2">
-				{apps.map((app) => <AppCard app={app} />)}
+				{apps.map((app, i) => <AppCard app={app} featured={i === 0} />)}
 			</div>
 		) : (
 			<p class="py-8 text-text-faint">暂无应用，敬请期待。</p>

--- a/src/pages/blog/timeline.astro
+++ b/src/pages/blog/timeline.astro
@@ -239,7 +239,8 @@ const monthNames = [
 	setupToggle(tagWrapper, tagToggle);
 	setupToggle(catWrapper, catToggle);
 
-	const chips = document.querySelectorAll('.filter-chip');
+	// HTMLElement 声明：chips 需要读写 dataset（NodeList 泛型默认 Element 没有 dataset）
+	const chips = document.querySelectorAll<HTMLElement>('.filter-chip');
 	const posts = document.querySelectorAll('.timeline-post');
 	const clearBtn = document.getElementById('clear-filters');
 	let activeTag = '';
@@ -375,7 +376,8 @@ const monthNames = [
 			} else if (filterType === 'category') {
 				activeCategory = activeCategory === value ? '' : value;
 			}
-			syncGroupHighlight(filterType);
+			// getAttribute 可能为 null：非 tag/category 时传空串（函数内不会匹配任何 chip）
+			syncGroupHighlight(filterType ?? '');
 			applyFilters();
 		});
 	});

--- a/src/pages/contact.astro
+++ b/src/pages/contact.astro
@@ -22,7 +22,7 @@ const githubIssues = 'https://github.com/tzzs/tzzs.github.io/issues';
 		</header>
 
 		<div class="mt-12 grid grid-cols-1 gap-4 md:grid-cols-2">
-			<section class="rounded-[var(--radius-card)] border-2 border-black bg-gray p-7 transition-all duration-200 hover:-translate-y-0.5 hover:shadow-[var(--shadow)]">
+			<section class="rounded-[var(--radius-card)] border-2 border-[light-dark(#191a23,#4f515c)] bg-[var(--bg-soft)] p-7 transition-all duration-200 hover:-translate-y-0.5 hover:shadow-[var(--shadow)]">
 				<div class="flex items-center justify-between gap-4">
 					<h2 class="text-xl font-medium">GitHub Issues</h2>
 					<span class="inline-flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-green" aria-hidden="true">
@@ -38,7 +38,7 @@ const githubIssues = 'https://github.com/tzzs/tzzs.github.io/issues';
 				</p>
 			</section>
 
-			<section class="rounded-[var(--radius-card)] border-2 border-black bg-gray p-7 transition-all duration-200 hover:-translate-y-0.5 hover:shadow-[var(--shadow)]">
+			<section class="rounded-[var(--radius-card)] border-2 border-[light-dark(#191a23,#4f515c)] bg-[var(--bg-soft)] p-7 transition-all duration-200 hover:-translate-y-0.5 hover:shadow-[var(--shadow)]">
 				<div class="flex items-center justify-between gap-4">
 					<h2 class="text-xl font-medium">开源主页</h2>
 					<span class="inline-flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-green" aria-hidden="true">
@@ -53,7 +53,7 @@ const githubIssues = 'https://github.com/tzzs/tzzs.github.io/issues';
 				</p>
 			</section>
 
-			<section class="rounded-[var(--radius-card)] border-2 border-black bg-gray p-7 transition-all duration-200 hover:-translate-y-0.5 hover:shadow-[var(--shadow)] md:col-span-2">
+			<section class="rounded-[var(--radius-card)] border-2 border-[light-dark(#191a23,#4f515c)] bg-[var(--bg-soft)] p-7 transition-all duration-200 hover:-translate-y-0.5 hover:shadow-[var(--shadow)] md:col-span-2">
 				<div class="flex items-center justify-between gap-4">
 					<h2 class="text-xl font-medium">说明</h2>
 					<span class="inline-flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-green" aria-hidden="true">

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -87,7 +87,7 @@ class="w-full max-w-sm overflow-hidden rounded-[2rem] border border-white/10 bg-
 		<div class="mb-10 flex flex-col items-start gap-4 sm:flex-row sm:items-center sm:gap-10">
 			<h2
 				id="apps-heading"
-				class="w-fit shrink-0 rounded-lg bg-green px-2.5 py-1.5 text-3xl font-medium sm:text-4xl"
+				class="w-fit shrink-0 rounded-lg bg-green px-2.5 py-1.5 text-3xl font-medium text-black sm:text-4xl"
 			>
 				正在发布的应用
 			</h2>
@@ -128,7 +128,7 @@ class="w-full max-w-sm overflow-hidden rounded-[2rem] border border-white/10 bg-
 		<div class="mb-10 flex flex-col items-start gap-4 sm:flex-row sm:items-center sm:gap-10">
 			<h2
 				id="blog-heading"
-				class="w-fit shrink-0 rounded-lg bg-green px-2.5 py-1.5 text-3xl font-medium sm:text-4xl"
+				class="w-fit shrink-0 rounded-lg bg-green px-2.5 py-1.5 text-3xl font-medium text-black sm:text-4xl"
 			>
 				最近文章
 			</h2>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -109,7 +109,15 @@ class="w-full max-w-sm overflow-hidden rounded-[2rem] border border-white/10 bg-
 		{
 			apps.length > 0 && (
 				<div class="mt-10 text-center">
-					<a class="font-medium text-accent hover:underline" href="/apps/">查看全部应用 →</a>
+					<a
+					class="group inline-flex items-center gap-2 rounded-full border border-[var(--border)] px-6 py-2.5 text-sm font-medium text-[var(--text-soft)] transition-colors duration-200 hover:border-[var(--accent)] hover:text-[var(--accent)]"
+					href="/apps/"
+				>
+					查看全部应用
+					<svg class="h-4 w-4 transition-transform duration-200 group-hover:translate-x-0.5" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor">
+						<path stroke-linecap="round" stroke-linejoin="round" d="M5 12h14m0 0l-6-6m6 6l-6 6" />
+					</svg>
+				</a>
 				</div>
 			)
 		}
@@ -173,7 +181,15 @@ class="w-full max-w-sm overflow-hidden rounded-[2rem] border border-white/10 bg-
 		{
 			recentPosts.length > 0 && (
 				<div class="mt-10 text-center">
-					<a class="font-medium text-accent hover:underline" href="/blog/">查看全部文章 →</a>
+					<a
+					class="group inline-flex items-center gap-2 rounded-full border border-[var(--border)] px-6 py-2.5 text-sm font-medium text-[var(--text-soft)] transition-colors duration-200 hover:border-[var(--accent)] hover:text-[var(--accent)]"
+					href="/blog/"
+				>
+					查看全部文章
+					<svg class="h-4 w-4 transition-transform duration-200 group-hover:translate-x-0.5" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor">
+						<path stroke-linecap="round" stroke-linejoin="round" d="M5 12h14m0 0l-6-6m6 6l-6 6" />
+					</svg>
+				</a>
 				</div>
 			)
 		}

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -2,15 +2,27 @@
 // 门户首页（Positivus 落地页风格）：Hero + 应用展示 + 最近文章 + 关于片段
 import { getCollection } from 'astro:content';
 import MainLayout from '../layouts/MainLayout.astro';
-import PostCard from '../components/PostCard.astro';
 import AppCard from '../components/AppCard.astro';
 import { apps } from '../data/apps';
 import { SITE_TITLE, SITE_DESCRIPTION } from '../consts';
 
-// 最近文章：仅非草稿，按发布时间降序取 5 篇
-const recentPosts = (await getCollection('blog', ({ data }) => !data.draft))
-	.sort((a, b) => b.data.pubDate.valueOf() - a.data.pubDate.valueOf())
-	.slice(0, 5);
+// 全部文章（仅非草稿，按发布时间降序）；recentPosts 取前 5 篇，postCount 用于关于区数据
+const allPosts = (await getCollection('blog', ({ data }) => !data.draft)).sort(
+	(a, b) => b.data.pubDate.valueOf() - a.data.pubDate.valueOf(),
+);
+const recentPosts = allPosts.slice(0, 5);
+const postCount = allPosts.length;
+
+// 关于区技术栈标签（浅色变体 pill，用于深色卡片上）
+const techStack = ['VS Code 扩展', 'Windows 桌面', 'Java', 'Spring', 'Vue', 'Go', 'TypeScript'];
+
+// 列表式日期：YYYY-MM-DD（等宽数字，与时间轴风格一致）
+const formatDate = (d: Date) => {
+	const y = d.getFullYear();
+	const m = String(d.getMonth() + 1).padStart(2, '0');
+	const day = String(d.getDate()).padStart(2, '0');
+	return `${y}-${m}-${day}`;
+};
 ---
 
 <MainLayout title={SITE_TITLE} description={SITE_DESCRIPTION}>
@@ -41,18 +53,18 @@ class="w-full max-w-sm overflow-hidden rounded-[2rem] border border-white/10 bg-
 				<span class="h-3 w-3 rounded-full bg-[#ff5f57]"></span>
 				<span class="h-3 w-3 rounded-full bg-[#febc2e]"></span>
 				<span class="h-3 w-3 rounded-full bg-[#28c840]"></span>
-				<span class="ml-3 font-mono text-xs text-white/50">tzzs@portal — zsh</span>
+				<span class="ml-3 font-mono text-xs text-white/50">tzzs@portal · zsh</span>
 			</div>
 			<div class="space-y-4 px-6 py-7 font-mono text-sm">
-				<div>
+				<div class="terminal-line">
 					<p><span class="text-green">➜</span> <span class="text-white/80">~</span> <span class="text-white/80">whoami</span></p>
 					<p class="mt-1 text-5xl font-bold text-green">TZZ</p>
 				</div>
-				<div>
+				<div class="terminal-line">
 					<p><span class="text-green">➜</span> <span class="text-white/80">~</span> <span class="text-white/80">role</span></p>
 					<p class="mt-1 text-white/90">独立开发者</p>
 				</div>
-				<div>
+				<div class="terminal-line">
 					<p><span class="text-green">➜</span> <span class="text-white/80">~</span> <span class="text-white/80">stack</span></p>
 					<p class="mt-1">
 						<span
@@ -62,7 +74,7 @@ class="w-full max-w-sm overflow-hidden rounded-[2rem] border border-white/10 bg-
 						</span>
 					</p>
 				</div>
-				<p class="text-white/40">
+				<p class="terminal-line text-white/40">
 					<span class="text-green">➜</span> <span class="text-white/80">~</span> <span class="inline-block h-4 w-2 animate-pulse bg-green/80 align-middle"></span>
 				</p>
 				</div>
@@ -86,7 +98,7 @@ class="w-full max-w-sm overflow-hidden rounded-[2rem] border border-white/10 bg-
 		{
 			apps.length > 0 ? (
 				<div class="grid gap-6 md:grid-cols-2">
-					{apps.map((app) => <AppCard app={app} />)}
+					{apps.map((app, i) => <AppCard app={app} featured={i === 0} />)}
 				</div>
 			) : (
 				<p class="rounded-2xl border border-dashed border-border px-6 py-12 text-center text-text-faint">
@@ -118,8 +130,39 @@ class="w-full max-w-sm overflow-hidden rounded-[2rem] border border-white/10 bg-
 		</div>
 		{
 			recentPosts.length > 0 ? (
-				<div class="flex flex-col gap-6">
-					{recentPosts.map((post) => <PostCard post={post} />)}
+				/* 分隔列表式：与上方应用卡片网格形成节奏对比（日期 + 标题 + 摘要） */
+				<div class="overflow-hidden rounded-2xl border border-[var(--border)] bg-[var(--bg)]">
+					<div class="divide-y divide-[var(--border)]">
+						{
+							recentPosts.map((post) => (
+								<a
+									href={`/blog/${post.id}/`}
+									class="group flex flex-col gap-1.5 px-6 py-5 transition-colors duration-150 hover:bg-[var(--bg-soft)] sm:flex-row sm:items-baseline sm:gap-6"
+								>
+									<time
+										class="shrink-0 font-mono text-sm text-[var(--text-faint)] tabular-nums"
+										datetime={post.data.pubDate.toISOString()}
+									>
+										{formatDate(post.data.pubDate)}
+									</time>
+									<span class="min-w-0 flex-1">
+										<span
+											class="block font-semibold text-[var(--text)] transition-colors duration-150 group-hover:text-[var(--accent)]"
+										>
+											{post.data.title}
+										</span>
+										{
+											post.data.description && (
+												<span class="mt-0.5 block truncate text-sm text-[var(--text-soft)]">
+													{post.data.description}
+												</span>
+											)
+										}
+									</span>
+								</a>
+							))
+						}
+					</div>
 				</div>
 			) : (
 				<p class="rounded-2xl border border-dashed border-border px-6 py-12 text-center text-text-faint">
@@ -136,27 +179,40 @@ class="w-full max-w-sm overflow-hidden rounded-[2rem] border border-white/10 bg-
 		}
 	</section>
 
-	<!-- ===== About 片段 ===== -->
+	<!-- ===== 关于开发者 =====
+	直接以深色横幅呈现（不再用绿块 header，避免与上方两个区块同构） -->
 	<section aria-labelledby="about-heading" class="mt-16 sm:mt-24">
-		<div class="mb-10 flex flex-col items-start gap-4 sm:flex-row sm:items-center sm:gap-10">
-			<h2
-				id="about-heading"
-				class="w-fit shrink-0 rounded-lg bg-green px-2.5 py-1.5 text-3xl font-medium sm:text-4xl"
-			>
-				关于开发者
-			</h2>
-			<p class="text-text-soft sm:max-w-[560px]">介绍一下我，以及我平时在折腾的技术。</p>
-		</div>
 		<div
-			class="flex flex-col gap-8 rounded-[2rem] bg-black p-8 text-white sm:p-12 lg:flex-row lg:items-center lg:justify-between"
+			class="flex flex-col gap-10 rounded-[2rem] bg-black p-8 text-white sm:p-12 lg:flex-row lg:items-start lg:justify-between"
 		>
 			<div class="max-w-2xl">
-				<h3 class="text-2xl font-bold">你好，我是 TZZ</h3>
-				<p class="mt-3 leading-relaxed text-white/70">
-					独立开发者。
+				<h2 id="about-heading" class="text-3xl font-bold sm:text-4xl">你好，我是 TZZ</h2>
+				<p class="mt-4 leading-relaxed text-white/70">
+					独立开发者，专注 VS Code 扩展与 Windows 桌面工具，也在博客里记录技术踩坑与工程实践。
 				</p>
+				<ul class="mt-6 flex flex-wrap gap-2" aria-label="技术栈">
+					{
+						techStack.map((tech) => (
+							<li class="rounded-full border border-white/20 px-2.5 py-0.5 text-xs text-white/70">
+								{tech}
+							</li>
+						))
+					}
+				</ul>
 			</div>
-			<a class="btn-tertiary w-fit shrink-0" href="/about/">了解更多 →</a>
+			<div class="flex shrink-0 flex-col gap-8 lg:items-end">
+				<dl class="flex gap-12 lg:flex-col lg:gap-4">
+					<div>
+						<dt class="text-sm text-white/50">博客文章</dt>
+						<dd class="mt-1 font-mono text-3xl font-bold text-green">{postCount}</dd>
+					</div>
+					<div>
+						<dt class="text-sm text-white/50">已发布应用</dt>
+						<dd class="mt-1 font-mono text-3xl font-bold text-green">{apps.length}</dd>
+					</div>
+				</dl>
+				<a class="btn-tertiary w-fit" href="/about/">了解更多 →</a>
+			</div>
 		</div>
 	</section>
 </MainLayout>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -3,22 +3,22 @@
 
 /* ===== Tailwind 4 主题令牌（@theme） ===== */
 @theme {
-  /* Positivus 色板 */
+  /* Positivus 色板（深色模式下深块提亮一级，维持层次） */
   --color-green: #b9ff66;
-  --color-black: #191a23;
-  --color-dark: #292a32;
+  --color-black: light-dark(#191a23, #21262d);
+  --color-dark: light-dark(#292a32, #21262d);
   --color-gray: #f3f3f3;
   --color-white: #ffffff;
 
-  /* 站点语义色 */
-  --color-accent: #0969da;
-  --color-accent-soft: #ddf4ff;
-  --color-text: #1f2328;
-  --color-text-soft: #57606a;
-  --color-text-faint: #8b949e;
-  --color-border: #d0d7de;
-  --color-bg: #ffffff;
-  --color-bg-soft: #f6f8fa;
+  /* 站点语义色：引用 :root 语义变量（light-dark 跟随系统，data-theme 手动覆盖） */
+  --color-accent: var(--accent);
+  --color-accent-soft: var(--accent-soft);
+  --color-text: var(--text);
+  --color-text-soft: var(--text-soft);
+  --color-text-faint: var(--text-faint);
+  --color-border: var(--border);
+  --color-bg: var(--bg);
+  --color-bg-soft: var(--bg-soft);
 
   /* 状态徽章色 */
   --color-status-dev: #9a6700;
@@ -38,54 +38,36 @@
   --radius-card: 14px;
 }
 
-/* ===== 语义 CSS 变量（组件样式 + 深色模式） ===== */
+/* ===== 语义 CSS 变量（组件样式 + 深色模式） =====
+   light-dark(浅色值, 深色值) 跟随系统偏好；[data-theme] 手动覆盖 color-scheme 强制翻转 */
 :root {
-  --bg: #ffffff;
-  --bg-soft: #f6f8fa;
-  --bg-hover: #eef1f4;
-  --text: #1f2328;
-  --text-soft: #57606a;
-  --text-faint: #8b949e;
-  --border: #d0d7de;
-  --border-strong: #afb8c1;
-  --accent: #0969da;
-  --accent-soft: #ddf4ff;
-  --code-bg: #f6f8fa;
-  --code-text: #24292f;
-  --shadow: 0 1px 3px rgba(31, 35, 40, 0.08), 0 4px 12px rgba(31, 35, 40, 0.06);
+  color-scheme: light dark;
+  --bg: light-dark(#ffffff, #0d1117);
+  --bg-soft: light-dark(#f6f8fa, #161b22);
+  --bg-hover: light-dark(#eef1f4, #1c2129);
+  --text: light-dark(#1f2328, #e6edf3);
+  --text-soft: light-dark(#57606a, #9da7b3);
+  --text-faint: light-dark(#8b949e, #6e7681);
+  --border: light-dark(#d0d7de, #30363d);
+  --border-strong: light-dark(#afb8c1, #484f58);
+  --accent: light-dark(#0969da, #4493f8);
+  --accent-soft: light-dark(#ddf4ff, #0c2d6b);
+  --code-bg: light-dark(#f6f8fa, #161b22);
+  --code-text: light-dark(#24292f, #e6edf3);
+  --shadow: light-dark(0 1px 3px rgba(31, 35, 40, 0.08), 0 1px 3px rgba(1, 4, 9, 0.6));
   --radius: 8px;
-  /* 深色模式适配用：描边文字 / 滚动后导航浮层 */
-  --outline-color: #191a23;
-  --nav-bg: rgba(255, 255, 255, 0.9);
-  --nav-border: #d0d7de;
+  /* 描边文字 / 滚动后导航浮层 */
+  --outline-color: light-dark(#191a23, #e6edf3);
+  --nav-bg: light-dark(rgba(255, 255, 255, 0.9), rgba(13, 17, 23, 0.9));
+  --nav-border: light-dark(#d0d7de, #30363d);
 }
 
-@media (prefers-color-scheme: dark) {
-  :root {
-    --bg: #0d1117;
-    --bg-soft: #161b22;
-    --bg-hover: #1c2129;
-    --text: #e6edf3;
-    --text-soft: #9da7b3;
-    --text-faint: #6e7681;
-    --border: #30363d;
-    --border-strong: #484f58;
-    --accent: #4493f8;
-    --accent-soft: #0c2d6b;
-    --code-bg: #161b22;
-    --code-text: #e6edf3;
-    --shadow: 0 1px 3px rgba(1, 4, 9, 0.6);
-    /* 深色模式下描边文字用浅色，避免黑描边在黑背景上隐形 */
-    --outline-color: #e6edf3;
-    --nav-bg: rgba(13, 17, 23, 0.9);
-    --nav-border: #30363d;
-  }
-
-  /* 深色面板（bg-dark / bg-black）在深色页面上提亮一级，维持深块层次 */
-  .bg-dark,
-  .bg-black {
-    background-color: #21262d;
-  }
+/* 手动主题覆盖：强制 color-scheme 即可让所有 light-dark() 变量翻转 */
+:root[data-theme="light"] {
+  color-scheme: light;
+}
+:root[data-theme="dark"] {
+  color-scheme: dark;
 }
 
 /* ===== 字体 ===== */
@@ -563,11 +545,9 @@ body {
   }
 }
 
-/* ===== KaTeX 深色模式兼容 ===== */
-@media (prefers-color-scheme: dark) {
-  .katex {
-    color: var(--text);
-  }
+/* ===== KaTeX：公式颜色跟随主题文字色（--text 已随主题翻转） ===== */
+.katex {
+  color: var(--text);
 }
 
 /* ===== 工具类 ===== */

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -54,6 +54,10 @@
   --code-text: #24292f;
   --shadow: 0 1px 3px rgba(31, 35, 40, 0.08), 0 4px 12px rgba(31, 35, 40, 0.06);
   --radius: 8px;
+  /* 深色模式适配用：描边文字 / 滚动后导航浮层 */
+  --outline-color: #191a23;
+  --nav-bg: rgba(255, 255, 255, 0.9);
+  --nav-border: #d0d7de;
 }
 
 @media (prefers-color-scheme: dark) {
@@ -71,6 +75,16 @@
     --code-bg: #161b22;
     --code-text: #e6edf3;
     --shadow: 0 1px 3px rgba(1, 4, 9, 0.6);
+    /* 深色模式下描边文字用浅色，避免黑描边在黑背景上隐形 */
+    --outline-color: #e6edf3;
+    --nav-bg: rgba(13, 17, 23, 0.9);
+    --nav-border: #30363d;
+  }
+
+  /* 深色面板（bg-dark / bg-black）在深色页面上提亮一级，维持深块层次 */
+  .bg-dark,
+  .bg-black {
+    background-color: #21262d;
   }
 }
 
@@ -101,13 +115,13 @@ body {
   -webkit-font-smoothing: antialiased;
 }
 
-/* Positivus 文本轮廓类 */
+/* Positivus 文本轮廓类（描边色随主题：浅色黑描边 / 深色浅描边） */
 .font-outline {
-  -webkit-text-stroke: 2.5px black;
+  -webkit-text-stroke: 2.5px var(--outline-color);
   background-color: transparent;
 }
 .font-outline-sm {
-  -webkit-text-stroke: 1.2px black;
+  -webkit-text-stroke: 1.2px var(--outline-color);
   background-color: transparent;
 }
 
@@ -460,6 +474,40 @@ body {
 }
 .collapsible-wrapper.expanded {
   max-height: 50rem;
+}
+
+/* ===== Hero 终端：命令逐行入场（stagger 淡入） ===== */
+.terminal-line {
+  opacity: 0;
+  animation: terminal-line-in 0.5s cubic-bezier(0.16, 1, 0.3, 1) forwards;
+}
+.terminal-line:nth-child(1) {
+  animation-delay: 0.15s;
+}
+.terminal-line:nth-child(2) {
+  animation-delay: 0.45s;
+}
+.terminal-line:nth-child(3) {
+  animation-delay: 0.75s;
+}
+.terminal-line:nth-child(4) {
+  animation-delay: 1.05s;
+}
+@keyframes terminal-line-in {
+  from {
+    opacity: 0;
+    transform: translateY(4px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+@media (prefers-reduced-motion: reduce) {
+  .terminal-line {
+    opacity: 1;
+    animation: none;
+  }
 }
 
 /* ===== KaTeX 深色模式兼容 ===== */

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -209,13 +209,13 @@ body {
 
   /* 分页 */
   .pagination {
-    @apply mt-8 flex items-center justify-between gap-4;
+    @apply mt-8 flex flex-wrap items-center justify-between gap-4;
   }
-  .pagination a,
-  .pagination span {
+  .pagination > a,
+  .pagination > span {
     @apply inline-flex items-center rounded-lg border border-border px-4 py-2 text-sm;
   }
-  .pagination a {
+  .pagination > a {
     @apply transition-colors duration-150 hover:border-accent hover:text-accent;
     color: var(--text);
     text-decoration: none;
@@ -223,7 +223,32 @@ body {
   .pagination-disabled {
     color: var(--text-faint);
   }
-  .pagination-info {
+  /* 页码列表：方形按钮，当前页高亮为实底，省略号占位不可点 */
+  .pagination-pages {
+    @apply flex items-center gap-1.5;
+    margin: 0;
+    padding: 0;
+    list-style: none;
+  }
+  .pagination-pages li {
+    margin: 0;
+  }
+  .pagination-pages a,
+  .pagination-pages .page-current,
+  .pagination-pages .page-ellipsis {
+    @apply inline-flex h-9 min-w-9 items-center justify-center rounded-lg border border-border px-2 text-sm;
+    text-decoration: none;
+  }
+  .pagination-pages a {
+    @apply transition-colors duration-150 hover:border-accent hover:text-accent;
+    color: var(--text);
+  }
+  .pagination-pages .page-current {
+    @apply border-accent bg-accent;
+    color: #fff;
+  }
+  .pagination-pages .page-ellipsis {
+    border-color: transparent;
     color: var(--text-faint);
   }
 }

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -5,6 +5,8 @@
 @theme {
   /* Positivus 色板（深色模式下深块提亮一级，维持层次） */
   --color-green: #b9ff66;
+  /* 强调绿：白天用深绿保证浅底上可见，夜间用品牌浅绿 */
+  --color-green-strong: light-dark(#65a30d, #b9ff66);
   --color-black: light-dark(#191a23, #21262d);
   --color-dark: light-dark(#292a32, #21262d);
   --color-gray: #f3f3f3;
@@ -42,24 +44,24 @@
    light-dark(浅色值, 深色值) 跟随系统偏好；[data-theme] 手动覆盖 color-scheme 强制翻转 */
 :root {
   color-scheme: light dark;
-  --bg: light-dark(#ffffff, #0d1117);
-  --bg-soft: light-dark(#f6f8fa, #161b22);
-  --bg-hover: light-dark(#eef1f4, #1c2129);
+  --bg: light-dark(#ffffff, #191a23);
+  --bg-soft: light-dark(#f6f8fa, #21262d);
+  --bg-hover: light-dark(#eef1f4, #292a32);
   --text: light-dark(#1f2328, #e6edf3);
   --text-soft: light-dark(#57606a, #9da7b3);
-  --text-faint: light-dark(#8b949e, #6e7681);
-  --border: light-dark(#d0d7de, #30363d);
-  --border-strong: light-dark(#afb8c1, #484f58);
+  --text-faint: light-dark(#8b949e, #7d8590);
+  --border: light-dark(#d0d7de, #3d3f4a);
+  --border-strong: light-dark(#afb8c1, #4f515c);
   --accent: light-dark(#0969da, #4493f8);
   --accent-soft: light-dark(#ddf4ff, #0c2d6b);
-  --code-bg: light-dark(#f6f8fa, #161b22);
+  --code-bg: light-dark(#f6f8fa, #21262d);
   --code-text: light-dark(#24292f, #e6edf3);
   --shadow: light-dark(0 1px 3px rgba(31, 35, 40, 0.08), 0 1px 3px rgba(1, 4, 9, 0.6));
   --radius: 8px;
   /* 描边文字 / 滚动后导航浮层 */
   --outline-color: light-dark(#191a23, #e6edf3);
-  --nav-bg: light-dark(rgba(255, 255, 255, 0.9), rgba(13, 17, 23, 0.9));
-  --nav-border: light-dark(#d0d7de, #30363d);
+  --nav-bg: light-dark(rgba(255, 255, 255, 0.9), rgba(25, 26, 35, 0.9));
+  --nav-border: light-dark(#d0d7de, #3d3f4a);
 }
 
 /* 手动主题覆盖：强制 color-scheme 即可让所有 light-dark() 变量翻转 */

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -328,6 +328,9 @@ body {
   padding: 0;
   background: none;
   font-size: 0.9em;
+  /* 无语言代码块（shiki 纯文本渲染）token 无内联色：
+     必须继承 pre 的主题前景色，否则被 .prose code 的浅色变量覆盖成黑底黑字 */
+  color: inherit;
 }
 .prose table {
   width: 100%;

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -223,6 +223,31 @@ body {
   .pagination-disabled {
     color: var(--text-faint);
   }
+  .pagination-center {
+    @apply flex flex-wrap items-center justify-center gap-3;
+  }
+  /* 跳页输入框：数字输入 + 跳转按钮，回车或点击均可 */
+  .pagination-jump {
+    @apply inline-flex items-center gap-1.5 text-sm;
+    color: var(--text-faint);
+  }
+  .pagination-jump input {
+    @apply h-9 w-14 rounded-lg border border-border bg-bg px-2 text-center text-sm;
+    color: var(--text);
+  }
+  .pagination-jump input:focus {
+    border-color: var(--accent);
+    outline: none;
+  }
+  .pagination-jump button {
+    @apply inline-flex h-9 items-center rounded-lg border border-border px-3 text-sm transition-colors duration-150;
+    color: var(--text);
+    background: var(--bg);
+    cursor: pointer;
+  }
+  .pagination-jump button:hover {
+    @apply border-accent text-accent;
+  }
   /* 页码列表：方形按钮，当前页高亮为实底，省略号占位不可点 */
   .pagination-pages {
     @apply flex items-center gap-1.5;

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -111,6 +111,12 @@ body {
 
 /* ===== 组件层 ===== */
 @layer components {
+  /* 绿底块统一黑字：夜间模式下继承的浅色文字在绿底上不可读，绿块文字一律用 Positivus 黑
+     （显式 text-* 工具类优先级更高，仍可覆盖） */
+  .bg-green {
+    color: var(--color-black);
+  }
+
   /* 按钮（Positivus 风格） */
   .btn-primary {
     @apply inline-flex items-center justify-center gap-2 rounded-xl border border-black bg-black px-7 py-4 font-medium text-white transition-colors duration-200 hover:bg-dark;


### PR DESCRIPTION
## 概述

本轮 UI 优化覆盖站点多个模块，包含 24 个提交（时间轴导航调整 → 主题切换 → 卡片 hover 微调）。

## 主要变更

### 导航与页面结构
- 顶部导航移除「时间轴」入口（从博客页横幅进入），修复时间轴页高亮「博客」的问题
- 页脚移除时间轴入口并压缩高度（257px → 195px）
- 主页「查看全部应用/文章」升级为 pill 幽灵按钮

### 主题切换（新增）
- 导航栏新增太阳/月亮主题切换按钮，选择持久化（localStorage）
- 深色模式机制重构：语义变量改用 `light-dark()` 跟随系统，`html[data-theme]` 手动覆盖，移除 3 处媒体查询深色块
- 修复既有 bug：`bg-bg` 等 Tailwind 语义色类在深色模式下不翻转
- 夜间色阶向 Positivus 灰系提亮，统一绿底块黑字、联系页卡片语义色

### 博客分页
- 总页数 ≤7 全量显示页码 + 跳页输入框（`define:vars` 脚本）

### 应用卡片与详情页
- 卡片 hover：深色翻转 → 轻量风（标题绿底黑字块 + 边框品牌绿，白天深绿/夜间浅绿）
- 详情页：Hero 主 CTA 双迷你按钮、下载区胶囊按钮、子页导航圆形箭头卡片

### 修复
- 无语言代码块黑底黑字（`.prose pre code { color: inherit }`）
- 关于页 TZZ 夜间发灰、绿底标题夜间浅字不可读等

## 验证

- `astro check` 0 errors，`npm run build` 251 pages 通过
- 浏览器验证：深浅色切换/持久化、移动端布局、各页 hover 效果